### PR TITLE
Support binary token message

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:7.10
+
+    working_directory: ~/paseto.js
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run tests!
+      - run: npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: circleci/node:8.12.0-stretch
 
     working_directory: ~/paseto.js
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ build/Release
 # Dependency directories
 node_modules/
 jspm_packages/
+package-lock.json
 
 # Typescript v1 declaration files
 typings/
@@ -60,7 +61,7 @@ typings/
 
 # dotenv environment variables file
 .env
-
+.nvmrc
 
 
 # End of https://www.gitignore.io/api/node

--- a/lib/protocol/V2.js
+++ b/lib/protocol/V2.js
@@ -154,7 +154,7 @@ function __encrypt(data, key, footer, nonce, cb) {
     const header = utils.local(self);
 
     if (this._binary) {
-      [ data ] = (utils.parse('utf-8'))(data);
+      [ data ] = (utils.parse('binary'))(data);
       [ footer, nonce ] = (utils.parse('utf-8'))(footer, nonce);
     } else {
       [ data, footer, nonce ] = (utils.parse('utf-8'))(data, footer, nonce);
@@ -221,7 +221,8 @@ function decrypt(token, key, footer, cb) {
     try {
       [ header, payload, footer ] = decapsulate(header, token, footer);
 
-      data = aeadDecrypt(key, header, payload, footer);
+      const format = this._binary ? 'binary' : 'utf-8'
+      data = aeadDecrypt(key, header, payload, footer, format);
     } catch (ex) {
       return done(ex);
     }
@@ -413,7 +414,7 @@ function aeadEncrypt(key, header, plaintext, footer, nonce) {
  * @returns {Callback|Promise}
  */
 V2.prototype.aeadDecrypt = aeadDecrypt;
-function aeadDecrypt(key, header, payload, footer) {
+function aeadDecrypt(key, header, payload, footer, dataFormat) {
 
   // recover nonce
 
@@ -437,6 +438,5 @@ function aeadDecrypt(key, header, payload, footer) {
   const plaintext  = Buffer.from(_plaintext);
 
   // format
-
-  return plaintext.toString('utf-8');
+  return plaintext.toString(dataFormat);
 }

--- a/lib/protocol/V2.js
+++ b/lib/protocol/V2.js
@@ -106,6 +106,22 @@ function sklength() {
   return this._constants.SYMMETRIC_KEY_BYTES;
 }
 
+/***
+ * binary
+ *
+ * specify that the message in the token is binary data
+ *
+ * @function
+ * @api public
+ *
+ * @returns {V2}
+ */
+V2.prototype.binary = binary;
+function binary() {
+  this._binary = true;
+  return this;
+}
+
 
 /***
  * __encrypt
@@ -239,7 +255,12 @@ function sign(data, key, footer, cb) {
 
     const header = utils.public(self);
 
-    [ data, footer ] = (utils.parse('utf-8'))(data, footer);
+    if (this._binary) {
+      [ data ] = (utils.parse('binary'))(data);
+      [ footer ] = (utils.parse('utf-8'))(footer);
+    } else {
+      [ data, footer ] = (utils.parse('utf-8'))(data, footer);
+    }
 
     // sign
 
@@ -317,8 +338,8 @@ function verify(token, key, footer, cb) {
     if (!valid) { return done(new PasetoError('Invalid signature for this message')); }
 
     // format
-
-    return done(null, data.toString('utf-8'));
+    const format = this._binary ? 'binary' : 'utf-8'
+    return done(null, data.toString(format));
   });
 }
 

--- a/lib/protocol/V2.js
+++ b/lib/protocol/V2.js
@@ -153,7 +153,12 @@ function __encrypt(data, key, footer, nonce, cb) {
 
     const header = utils.local(self);
 
-    [ data, footer, nonce ] = (utils.parse('utf-8'))(data, footer, nonce);
+    if (this._binary) {
+      [ data ] = (utils.parse('utf-8'))(data);
+      [ footer, nonce ] = (utils.parse('utf-8'))(footer, nonce);
+    } else {
+      [ data, footer, nonce ] = (utils.parse('utf-8'))(data, footer, nonce);
+    }
 
     let token;
     try {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -114,7 +114,7 @@ function hkdf(alg) {
 module.exports.parse = parse;
 function parse(as) {
 
-  if ([ 'hex', 'base64', 'utf-8' ].indexOf(as) === -1) { throw new Error('Unknown format'); }
+  if ([ 'hex', 'base64', 'utf-8', 'binary' ].indexOf(as) === -1) { throw new Error('Unknown format'); }
   const parser = (as === 'base64') ? fromB64URLSafe : (i) => { return Buffer.from(i, as); }
 
   /***

--- a/test/V2.test.js
+++ b/test/V2.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const sodium = require('libsodium-wrappers-sumo');
+const zlib = require('zlib');
 
 const Paseto = require('../lib/paseto');
 
@@ -492,6 +493,94 @@ describe('Protocol V2', () => {
 
             assert.equal(typeof data, 'string');
             assert.equal(data, message);
+
+            return done();
+          })
+          .catch((err) => {
+            return done(err);
+          });
+      });
+    });
+
+    describe('binary', () => {
+
+      before(() => {
+        message = zlib.gzipSync(Buffer.from('testing')).toString('binary');
+      });
+
+      it('should sign and verify successfully - callback api', (done) => {
+
+        V2.binary().sign(message, sk, '', (err, token) => {
+          if (err) { return done(err); }
+
+          assert.equal(typeof token, 'string');
+          assert.equal(token.substring(0, 10), 'v2.public.');
+
+          V2.binary().verify(token, pk, '', (err, data) => {
+            if (err) { return done(err); }
+
+            assert.equal(typeof data, 'string');
+            assert.equal(zlib.gunzipSync(Buffer.from(data, 'binary')).toString(), 'testing');
+
+            done();
+          });
+        });
+      });
+
+      it('should sign and verify successfully - promise api', (done) => {
+
+        V2.binary().sign(message, sk, '')
+          .then((token) => {
+
+            assert.equal(typeof token, 'string');
+            assert.equal(token.substring(0, 10), 'v2.public.');
+
+            return V2.binary().verify(token, pk, '');
+          })
+          .then((data) => {
+            assert.equal(typeof data, 'string');
+            assert.equal(zlib.gunzipSync(Buffer.from(data, 'binary')).toString(), 'testing');
+
+            return done();
+          })
+          .catch((err) => {
+            return done(err);
+          });
+      });
+
+      it('should sign and verify successfully with footer - callback api', (done) => {
+
+        V2.binary().sign(message, sk, footer, (err, token) => {
+          if (err) { return done(err); }
+
+          assert.equal(typeof token, 'string');
+          assert.equal(token.substring(0, 10), 'v2.public.');
+
+          V2.binary().verify(token, pk, footer, (err, data) => {
+            if (err) { return done(err); }
+
+            assert.equal(typeof data, 'string');
+            assert.equal(zlib.gunzipSync(Buffer.from(data, 'binary')).toString(), 'testing');
+
+            done();
+          });
+        });
+      });
+
+      it('should sign and verify successfully with footer - promise api', (done) => {
+
+        V2.binary().sign(message, sk, footer)
+          .then((token) => {
+
+            assert.equal(typeof token, 'string');
+            assert.equal(token.substring(0, 10), 'v2.public.');
+
+            return V2.binary().verify(token, pk, footer);
+          })
+          .then((data) => {
+
+            assert.equal(typeof data, 'string');
+            assert.equal(zlib.gunzipSync(Buffer.from(data, 'binary')).toString(), 'testing');
 
             return done();
           })

--- a/test/V2.test.js
+++ b/test/V2.test.js
@@ -225,6 +225,95 @@ describe('Protocol V2', () => {
       });
     });
 
+    describe('binary', () => {
+
+      before(() => {
+        message = zlib.gzipSync(Buffer.from('test')).toString('binary');
+      });
+
+      it('should encrypt and decrypt successfully - callback api', (done) => {
+
+        V2.binary().encrypt(message, key, '', (err, token) => {
+          if (err) { return done(err); }
+
+          assert.equal(typeof token, 'string');
+          assert.equal(token.substring(0, 9), 'v2.local.');
+
+          V2.binary().decrypt(token, key, '', (err, data) => {
+            if (err) { return done(err); }
+
+            assert.equal(typeof data, 'string');
+            assert.equal(zlib.gunzipSync(Buffer.from(data, 'binary')).toString(), 'test');
+
+            done();
+          });
+        });
+      });
+
+      it('should encrypt and decrypt successfully - promise api', (done) => {
+
+        V2.binary().encrypt(message, key, '')
+          .then((token) => {
+
+            assert.equal(typeof token, 'string');
+            assert.equal(token.substring(0, 9), 'v2.local.');
+
+            return V2.binary().decrypt(token, key, '');
+          })
+          .then((data) => {
+
+            assert.equal(typeof data, 'string');
+            assert.equal(zlib.gunzipSync(Buffer.from(data, 'binary')).toString(), 'test');
+
+            return done();
+          })
+          .catch((err) => {
+            return done(err);
+          });
+      });
+
+      it('should encrypt and decrypt successfully with footer - callback api', (done) => {
+
+        V2.binary().encrypt(message, key, footer, (err, token) => {
+          if (err) { return done(err); }
+
+          assert.equal(typeof token, 'string');
+          assert.equal(token.substring(0, 9), 'v2.local.');
+
+          V2.binary().decrypt(token, key, footer, (err, data) => {
+            if (err) { return done(err); }
+
+            assert.equal(typeof data, 'string');
+            assert.equal(zlib.gunzipSync(Buffer.from(data, 'binary')).toString(), 'test');
+
+            done();
+          });
+        });
+      });
+
+      it('should encrypt and decrypt successfully with footer - promise api', (done) => {
+
+        V2.binary().encrypt(message, key, footer)
+          .then((token) => {
+
+            assert.equal(typeof token, 'string');
+            assert.equal(token.substring(0, 9), 'v2.local.');
+
+            return V2.binary().decrypt(token, key, footer);
+          })
+          .then((data) => {
+
+            assert.equal(typeof data, 'string');
+            assert.equal(zlib.gunzipSync(Buffer.from(data, 'binary')).toString(), 'test');
+
+            return done();
+          })
+          .catch((err) => {
+            return done(err);
+          });
+      });
+    });
+
     describe('errors', () => {
 
       const InvalidVersionError = require('../lib/error/InvalidVersionError');
@@ -505,7 +594,7 @@ describe('Protocol V2', () => {
     describe('binary', () => {
 
       before(() => {
-        message = zlib.gzipSync(Buffer.from('testing')).toString('binary');
+        message = zlib.gzipSync(Buffer.from('test')).toString('binary');
       });
 
       it('should sign and verify successfully - callback api', (done) => {
@@ -520,7 +609,7 @@ describe('Protocol V2', () => {
             if (err) { return done(err); }
 
             assert.equal(typeof data, 'string');
-            assert.equal(zlib.gunzipSync(Buffer.from(data, 'binary')).toString(), 'testing');
+            assert.equal(zlib.gunzipSync(Buffer.from(data, 'binary')).toString(), 'test');
 
             done();
           });
@@ -539,7 +628,7 @@ describe('Protocol V2', () => {
           })
           .then((data) => {
             assert.equal(typeof data, 'string');
-            assert.equal(zlib.gunzipSync(Buffer.from(data, 'binary')).toString(), 'testing');
+            assert.equal(zlib.gunzipSync(Buffer.from(data, 'binary')).toString(), 'test');
 
             return done();
           })
@@ -560,7 +649,7 @@ describe('Protocol V2', () => {
             if (err) { return done(err); }
 
             assert.equal(typeof data, 'string');
-            assert.equal(zlib.gunzipSync(Buffer.from(data, 'binary')).toString(), 'testing');
+            assert.equal(zlib.gunzipSync(Buffer.from(data, 'binary')).toString(), 'test');
 
             done();
           });
@@ -580,7 +669,7 @@ describe('Protocol V2', () => {
           .then((data) => {
 
             assert.equal(typeof data, 'string');
-            assert.equal(zlib.gunzipSync(Buffer.from(data, 'binary')).toString(), 'testing');
+            assert.equal(zlib.gunzipSync(Buffer.from(data, 'binary')).toString(), 'test');
 
             return done();
           })


### PR DESCRIPTION
By default the module expects the token message to be UTF-8. That causes a problem in our current usage where the token content is gzipped during creation. After `toString('utf-8')` is called on the message buffer there is no way to get the original binary back. The goal of this PR is to add the ability to specify that the content is binary without breaking any backward compatibility.

@change/platform @change/fe-platform 